### PR TITLE
Try to fix a bug and add lastfm ban API invoking

### DIFF
--- a/coffee/player-lastfm.coffee
+++ b/coffee/player-lastfm.coffee
@@ -44,6 +44,12 @@ define ["jquery"], ($) ->
                 authToken: md5(params.username + md5(params.password))
             , callback, "POST"
 
+        ban: (params, callback)->
+            @_api "track.ban",
+                track: params.track
+                artist: params.artist
+            , callback, "POST"
+
         love: (params, callback)->
             @_api "track.love",
                 track: params.track

--- a/coffee/player-player.coffee
+++ b/coffee/player-player.coffee
@@ -266,6 +266,12 @@ define ['jquery',
             @playlist.blockSong @current, (playlist) ->
                 playlist.getSong undefined, (song) ->
                     self.playSong song
+
+            if @setting.config.lastfm
+                @setting.lastfm.ban
+                    track: song.title
+                    artist: song.artist
+                    sk: @setting.config.lastfm.key
     
         pause: ->
             @play_button.removeClass "pause-button"

--- a/css/style.v2.css
+++ b/css/style.v2.css
@@ -70,7 +70,7 @@ body {
     height: 40px;
     background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#f6f6f6), to(#efefef));
     background-image: -webkit-linear-gradient(top, #f6f6f6, #efefef);
-    position: absolute;
+    position: fixed;
     bottom: 0;
     left: 0;
     z-index: 500;


### PR DESCRIPTION
Try to fix scrolling bug in main page on Windows.
Add invoking of lastfm ban API when do blockSong in player.

Hello,
The main page can be scrolled under Windows system, I tried to fix it and it works in my browser(Chrome Version 31.0.1650.4 m).
And I also add invoking of lastfm ban API when do blockSong in player.
I'm sorry that I did all these in the same branch, it's my fault.
Thanks
